### PR TITLE
- Changed the way TenantId is retrived

### DIFF
--- a/createCustomerSubscriptionMPA.ps1
+++ b/createCustomerSubscriptionMPA.ps1
@@ -7,7 +7,7 @@ Param (
 $azContext = Get-AzContext
 $azProfile = [Microsoft.Azure.Commands.Common.Authentication.Abstractions.AzureRmProfileProvider]::Instance.Profile
 $profileClient = New-Object -TypeName Microsoft.Azure.Commands.ResourceManager.Common.RMProfileClient -ArgumentList ($azProfile)
-$token = $profileClient.AcquireAccessToken($azContext.Subscription.TenantId)
+$token = $profileClient.AcquireAccessToken($azContext.Tenant.Id)
 $authHeader = @{
     'Content-Type'='application/json'
     'Authorization'='Bearer ' + $token.AccessToken

--- a/getMCACustomersFromBillingAccount.ps1
+++ b/getMCACustomersFromBillingAccount.ps1
@@ -5,7 +5,7 @@
 $azContext = Get-AzContext
 $azProfile = [Microsoft.Azure.Commands.Common.Authentication.Abstractions.AzureRmProfileProvider]::Instance.Profile
 $profileClient = New-Object -TypeName Microsoft.Azure.Commands.ResourceManager.Common.RMProfileClient -ArgumentList ($azProfile)
-$token = $profileClient.AcquireAccessToken($azContext.Subscription.TenantId)
+$token = $profileClient.AcquireAccessToken($azContext.Tenant.Id)
 $authHeader = @{
     'Content-Type'  = 'application/json'
     'Authorization' = 'Bearer ' + $token.AccessToken


### PR DESCRIPTION
Changed the way Tenant Id is retrieved to make it work even if no subscriptions exists in the CSP/Partner tenant. Subscription property will return a null ref in that case